### PR TITLE
fixed Ubuntu anchor in Table of Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
 	- [ArchLinux](#arch-linux)
 - [Miscellaneous](#miscellaneous)
 - [Discussion Forums](#discussion-forums)
-    - [Ubuntu](#apple)
+    - [Ubuntu](#ubuntu-1)
     - [IRC channels](#irc-channels)
     - [Linux News, Apps, and more ....](#linux-news-apps-and-more-)
     - [Reddit](#reddit)


### PR DESCRIPTION
The Ubuntu link under "Discussion Forums" in the ToC section didn't work as it linked to "#apple"