### PR TITLE
Replace dead beginner's guide link for arch linux.

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,7 +568,7 @@ Two Chinese version of this list are available [here](https://github.com/alim0x/
 
 ### Arch Linux
 
-- [Beginners' guide](https://wiki.archlinux.org/index.php/Beginners%27_guide)
+- [Getting and installing Arch](https://wiki.archlinux.org/index.php/Category:Getting_and_installing_Arch)
 - [Installation guide](https://wiki.archlinux.org/index.php/Installation_guide)
 - [General recommendations](https://wiki.archlinux.org/index.php/General_recommendations)
 - [List of applications](https://wiki.archlinux.org/index.php/List_of_applications)


### PR DESCRIPTION
The beginner's guide has been removed from the wiki and it's not coming
back. You can read the relevant discussion here:

- https://www.reddit.com/r/archlinux/comments/4z7z0i/the_beginners_guide_has_been_removed_from_the_wiki/
- https://wiki.archlinux.org/index.php?title=Talk:Beginners%27_guide&oldid=443725#The_Great_Merge
- https://bbs.archlinux.org/viewtopic.php?id=216665

There are some archives of the beginner's guide but it's a bad idea to
link them since they'll become outdated as time passes.

Note: I didn't run `asort.py` since it made changes on other items as well.